### PR TITLE
Consider refactoring default binding system

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -21,6 +21,7 @@ Here is some text.[^1]
 
 [^1]: Here is a note.
 ~~~
+)
 
 The footnote number gets determined by an automatic counter whenever a new
 footnote gets inserted. The counter works with the default arabic numerals
@@ -28,18 +29,13 @@ and all other settings provided by `b:vimfootnotetype`. The automatic counter
 code is based on the code for the counting of HTML footnotes in [this post by
 Nick Coleman][3], adjusted slightly to work with Markdown footnotes.
 
-The script defines two mappings,
+To insert a footnote, hit `<Leader>f` in normal mode or type `[]`. Then
 
-~~~
-<Leader>f    Insert new footnote
-<Leader>r    Return from footnote
-~~~
+- A footnote mark will be inserted after the cursor,
+- A matching footnote mark will be inserted at the end of the file, and
+- a split window at the bottom will open, ready to edit the new footnote.
 
-To insert a footnote, type `<Leader>f`. A footnote mark will be inserted
-after the cursor. A matching footnote mark will be inserted at the end
-of the file. A new buffer will open in a split window at the bottom of
-your screen, ready to edit the new footnote. When you are done, type
-`<Leader>r` to close the split and return to the main text.
+When done, type `ZZ` to close the split and return to the main text.
 
 ![Screenshot][5]
 

--- a/doc/markdownfootnotes.txt
+++ b/doc/markdownfootnotes.txt
@@ -4,11 +4,13 @@ markdown-footnotes, add footnotes in markdown *markdown-footnotes* *footnotes*
 0. Introduction ~
                                           *markdown-footnotes-intro*
 
-To insert a footnote, type `<Leader>f`. A footnote mark will be inserted
-after the cursor. A matching footnote mark will be inserted at the end
-of the file. A new buffer will open in a split window at the bottom of
-your screen, ready to edit the new footnote. When you are done, type
-`<Leader>r` to close the split and return to the main text.
+To insert a footnote, hit `<Leader>f` in normal mode or type `[]`. Then
+
+- A footnote mark will be inserted after the cursor,
+- A matching footnote mark will be inserted at the end of the file, and
+- a split window at the bottom will open, ready to edit the new footnote.
+
+When done, type `ZZ` to close the split and return to the main text.
 
 ===========================================================================
 1. Commands ~

--- a/ftplugin/markdown/markdownfootnotes.vim
+++ b/ftplugin/markdown/markdownfootnotes.vim
@@ -106,24 +106,14 @@ endif
 
 " Mappings
 if !hasmapto('<Plug>AddVimFootnote', 'i') && mapcheck('<Leader>f', 'i') is# ''
-	imap <buffer> <Leader>f <Plug>AddVimFootnote
+  	inoreabbrev <buffer> [] <c-o>:exe "normal \<Plug>AddVimFootnote"<cr>
 endif
 if !hasmapto('<Plug>AddVimFootnote', 'n') && mapcheck('<Leader>f', 'n') is# ""
     nmap <buffer> <Leader>f <Plug>AddVimFootnote
 endif
 
-if !hasmapto('<Plug>ReturnFromFootnote', 'i') && mapcheck('<Leader>r', 'i') is# ''
-    imap <buffer> <Leader>r <Plug>ReturnFromFootnote
-endif
-if !hasmapto('<Plug>ReturnFromFootnote', 'n') && mapcheck('<Leader>r', 'n') is# ''
-    nmap <buffer> <Leader>r <Plug>ReturnFromFootnote
-endif
-
 nnoremap <buffer> <Plug>AddVimFootnote :<c-u>call markdownfootnotes#VimFootnotes('a')<CR>
 inoremap <buffer> <Plug>AddVimFootnote <C-O>:<c-u>call markdownfootnotes#VimFootnotes('a')<CR>
-
-inoremap <Plug>ReturnFromFootnote <C-O>:<c-u>q<CR><Right>
-nnoremap <Plug>ReturnFromFootnote :<c-u>q<CR><Right>
 
 " :Footnote commands
 command! -buffer -nargs=1 FootnoteNumber call markdownfootnotes#VimFootnoteNumber(<q-args>)


### PR DESCRIPTION
I've been waiting for the repository rebase (#5) to happen before opening this, but that time has come.

In the process of integrating various peoples' contributions, I noticed in @Konfekt's fork that he had significantly changed the default bindings, and even the way the insert mode mapping worked to be an abbreviation instead.

While I'm not sure his binding choices are the best ones to go with, they certainly open up an interesting point that I think needs review and discussion.

For reference  my own current bindings are as follows:

```vim
imap ^^ <Plug>AddVimFootnote
nmap <Leader>^ <Plug>AddVimFootnote
imap @@ <Plug>ReturnFromFootnote
nmap <Leader>@ <Plug>ReturnFromFootnote
```

What's here that we should consider using? Or at least documenting things users may want to do differently (i.e. abbreviations vs. mappings)?

Also see #15 for related discussion.