### PR TITLE
Add support for Rmarkdown file formats

### DIFF
--- a/ftplugin/rmd
+++ b/ftplugin/rmd
@@ -1,0 +1,1 @@
+markdown


### PR DESCRIPTION
Because of some plugins ```:set ft=markdown``` does not work for ```.Rmd``` files. Also vim supports rmd as a filetype and syntax